### PR TITLE
yuicompressor keeps complaining when using the 'short' keyword

### DIFF
--- a/src/animation.js
+++ b/src/animation.js
@@ -7,9 +7,9 @@
 		return {
 			
 			durations: {
-				short: 500,
+				'short': 500,
 				normal: 1000,
-				long: 2000
+				'long': 2000
 			},
 
 			defaults: {


### PR DESCRIPTION
yuicompressor [keeps complaining](http://yuilibrary.com/projects/yuicompressor/ticket/2528086) when using the `short` keyword .

Using quotes solved the problem for me.
