### PR TITLE
Added scaledWidth and scaledHeight properties to displayObject which are 

### DIFF
--- a/src/displayobject.js
+++ b/src/displayobject.js
@@ -38,6 +38,8 @@
 				rotation: 0,
 				width: 0,
 				height: 0,
+				scaledWidth: 0,
+				scaledHeight: 0,
 				stroke: "",
 				strokeColor: "",
 				strokeWidth: 0,
@@ -310,6 +312,12 @@
 			},
 			get height () {
 				return this._.height;
+			},
+			get scaledWidth () {
+				return this._.width * this.scalingX;
+			},
+			get scaledHeight () {
+				return this._.height * this.scalingY;
 			},
 			
 			// Method for binding an event to the object


### PR DESCRIPTION
Added scaledWidth and scaledHeight properties to displayObject which are equivilent to (obj.width \* obj.scalingX) and (obj.height \* obj.scalingY) respectively.
