### PR TITLE
When un/loading a scene, redraw canvas only once, instead of per object

### DIFF
--- a/src/scenes.js
+++ b/src/scenes.js
@@ -70,7 +70,7 @@
 						// Loop through all added objects
 						for (i = 0; i < l; i++) {
 							if (objects[i] !== undefined) {
-								objects[i].add();
+								objects[i].add(false);
 							}
 						}
 						
@@ -88,7 +88,7 @@
 						for (i = 0; i < l; i++) {
 							if (objects[i] !== undefined) {
 								// Remove the object from canvas
-								objects[i].remove();
+								objects[i].remove(false);
 							}
 						}
 						
@@ -107,7 +107,9 @@
 				}
 				this.current = name;
 				this.scenes[name].load();
-				
+
+				this.core.draw.redraw();
+
 				return this;
 			},
 			
@@ -115,7 +117,9 @@
 			unload: function (name) {
 				this.current = "none";
 				this.scenes[name].unload();
-				
+
+				this.core.draw.redraw();
+
 				return this;
 			}
 		};


### PR DESCRIPTION
When working with scenes with a lot of objects, redrawing the canvas when un/loading takes a lot of time. Instead of doing a per-object redraw, redraw only once per scene un/load.

In my test project, I've got a scene with a few hundred objects; this patch reduced time spent in `canvas.scenes.load("my-scene");` from 828 milliseconds to 33 milliseconds (96% time saved). Your mileage may vary with the number of objects.
- No change in API.
- Adding to, or removing objects from, already loaded scenes is unaffected.

While it looks like v3.0.0 in the pipeline, this would help v2.5.1 users.
