### PR TITLE
Added version number string to oCanvas.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,9 @@
 
 	// Define the oCanvas object
 	var oCanvas = {
+	    
+		// Version number of this oCanvas release.
+		version: "2.6.0",
 		
 		// Array containing all canvases created by oCanvas on the current page
 		canvasList: [],


### PR DESCRIPTION
It is sometimes desirable to know the version number of the package in use. A trivial modification to src/core.js provides this feature. 
