### PR TITLE
allow floating-point values for stroke width

### DIFF
--- a/src/style.js
+++ b/src/style.js
@@ -75,7 +75,7 @@
 						// Set the stroke object with correct values
 						stroke = {
 							pos: stroke[0],
-							width: parseInt(stroke[1]),
+							width: parseFloat(stroke[1]),
 							color: stroke[2]
 						};
 					}
@@ -87,7 +87,7 @@
 					// Set the stroke object
 					stroke = {
 						pos: "center",
-						width: parseInt(stroke[0]),
+						width: parseFloat(stroke[0]),
 						color: stroke[1]
 					};
 				}


### PR DESCRIPTION
oCanvas currently rounds stroke width to integer; in raw canvas, stroke width can be floating point, and even < 1.0. This is especially useful when there is a global scale/transform on the canvas ..
