### PR TITLE
Added clipping feature

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -92,12 +92,17 @@
 
 			drawObjects: function (objects) {
 				var canvas = this.core.canvas,
+					fillRectClipping = function() {
+						this.rect.apply(this, arguments);
+						this.fill();
+					},
+					fillRectOriginal = canvas.fillRect,
 					i, l, obj, object, x, y, objectChain, lastX, lastY, n, len, parent, shadow, opacity;
 
 				for (i = 0, l = objects.length; i < l; i++) {
 					obj = objects[i];
 					if ((obj !== undefined) && (typeof obj.draw === "function")) {
-						
+
 						// Update the object's properties if an update method is available
 						if (typeof obj.update === "function") {
 							obj.update();
@@ -105,54 +110,6 @@
 
 						// Temporarily move the canvas origin and take children's positions into account, so they will rotate around the parent
 						canvas.save();
-
-						// Create an array of all the parents to this object
-						objectChain = [];
-						objectChain.push(obj);
-						parent = obj.parent;
-						while (parent && parent !== this.core) {
-							objectChain.push(parent);
-							parent = parent.parent;
-						}
-						// Reverse the array so the top level parent comes first, and ends with the current object
-						objectChain.reverse();
-
-						// Loop through all objects in the parent chain
-						lastX = 0; lastY = 0;
-						opacity = 1;
-						for (n = 0, len = objectChain.length; n < len; n++) {
-							object = objectChain[n];
-
-							// Translate the canvas matrix to the position of the object
-							canvas.translate(object.abs_x - lastX, object.abs_y - lastY);
-							
-							// If the object has a rotation, rotate the canvas matrix
-							if (object.rotation !== 0) {
-								canvas.rotate(object.rotation * Math.PI / 180);
-							}
-							
-							// Scale the canvas for this object
-							if (object.scalingX !== 1 || object.scalingY !== 1) {
-								canvas.scale(object.scalingX, object.scalingY);
-							}
-
-							// Scale the opacity
-							opacity *= object.opacity;
-							
-							// Save the current translation so that the next iteration can subtract that
-							lastX = object.abs_x;
-							lastY = object.abs_y;
-						}
-
-						// Save the translation so that display objects can access this if they need
-						this.translation = { x: lastX, y: lastY };
-
-						// Automatically adjust the abs_x/abs_y for the object
-						// (objects not using these variables in the drawing process use the object created above)
-						x = obj.abs_x;
-						y = obj.abs_y;
-						obj._.abs_x = 0;
-						obj._.abs_y = 0;
 
 						// Set the alpha to match the object's opacity
 						canvas.globalAlpha = !isNaN(parseFloat(opacity)) ? parseFloat(opacity) : 1;
@@ -175,26 +132,29 @@
 						canvas.miterLimit = obj.miterLimit;
 
 						// Draw the object
-						obj.draw();
+						if(obj.clipChildren) {
+							canvas.fillRect = fillRectClipping;
+							obj.draw();
+							canvas.fillRect = fillRectOriginal;
+							canvas.clip();
+						} else {
+							obj.draw();
+						}
 						obj.drawn = true;
-
-						// Reset the abs_x/abs_y values
-						obj._.abs_x = x;
-						obj._.abs_y = y;
 
 						// Reset stroke properties
 						canvas.lineCap = "butt";
 						canvas.lineJoin = "miter";
 						canvas.miterLimit = 10;
 
-						// Restore the old transformation
-						canvas.restore();
-						this.translation = { x: 0, y: 0 };
-
 						// Loop children recursively to draw everything in the correct order
 						if (obj.children.length > 0) {
 							this.drawObjects(obj.children);
 						}
+
+						// Restore the old transformation
+						canvas.restore();
+						this.translation = { x: 0, y: 0 };
 					}
 				}
 			}


### PR DESCRIPTION
Now an object can "clip" its childs into its shape.

Before this change, the drawObject function restored the canvas before draw object's children. In that way, clipping feature was not possible.

Instead of restoring canvas and making again all parent's transformations, now the canvas is restored after children were drawn. This allows us to use the clip() function before draw the object's children.

I realized that the fillRect() function doesn't work fine with clip() -it paints the object over its children. That's the reason why I wrote the function fillRectClipping. This function executes a rect() then a fill() instead of a fillRect(). Using rect()+fill() the object is painted under its children.

Now the trick begins: when an object has a "clipChildren" property with a truthly value, the following happens:
    1. canvas.fillRect() function is replaced by fillRectClipping function (line 136).
    2. object's draw() function is invoked (line 137).
    3. canvas.fillRect() function is restored (line 138).
    4. canvas.clip() function is invoked (line 139).

When "clipChildren" property is not defined or it has a falsy value, only "obj.draw()" is invoked.