### PR TITLE
Added clipping feature

### DIFF
--- a/src/draw.js
+++ b/src/draw.js
@@ -102,7 +102,7 @@
 				for (i = 0, l = objects.length; i < l; i++) {
 					obj = objects[i];
 					if ((obj !== undefined) && (typeof obj.draw === "function")) {
-						
+
 						// Update the object's properties if an update method is available
 						if (typeof obj.update === "function") {
 							obj.update();
@@ -113,12 +113,12 @@
 
 						// Translate the canvas matrix to the position of the object
 						canvas.translate(obj.x, obj.y);
-						
+
 						// If the object has a rotation, rotate the canvas matrix
 						if (obj.rotation !== 0) {
 							canvas.rotate(obj.rotation * Math.PI / 180);
 						}
-						
+
 						// Scale the canvas for this object
 						if (obj.scalingX !== 1 || obj.scalingY !== 1) {
 							canvas.scale(obj.scalingX, obj.scalingY);
@@ -126,6 +126,11 @@
 
 						// Scale the opacity
 						opacity = obj.opacity;
+						var parent = obj.parent;
+						while(parent && parent !== this.core) {
+							opacity *= parent.opacity;
+							parent = parent.parent;
+						}
 
 						// Save the translation so that display objects can access this if they need
 						this.translation = { x: obj.abs_x, y: obj.abs_y };

--- a/src/draw.js
+++ b/src/draw.js
@@ -102,7 +102,7 @@
 				for (i = 0, l = objects.length; i < l; i++) {
 					obj = objects[i];
 					if ((obj !== undefined) && (typeof obj.draw === "function")) {
-
+						
 						// Update the object's properties if an update method is available
 						if (typeof obj.update === "function") {
 							obj.update();
@@ -126,6 +126,9 @@
 
 						// Scale the opacity
 						opacity = obj.opacity;
+
+						// Save the translation so that display objects can access this if they need
+						this.translation = { x: obj.abs_x, y: obj.abs_y };
 
 						// Automatically adjust the abs_x/abs_y for the object
 						// (objects not using these variables in the drawing process use the object created above)
@@ -181,6 +184,7 @@
 
 						// Restore the old transformation
 						canvas.restore();
+						this.translation = { x: 0, y: 0 };
 					}
 				}
 			}


### PR DESCRIPTION
Now an object can "clip" its childs into its shape.

Before this change, the drawObject function restored the canvas before draw object's children. In that way, clipping feature was not possible.

Instead of restoring canvas and making again all parent's transformations, now the canvas is restored after children were drawn. This allows us to use the clip() function before draw the object's children.

I realized that the fillRect() function doesn't work fine with clip() -it paints the object above its children. That's the reason why I wrote the function fillRectClipping. This function executes a rect() then a fill() instead of a fillRect(). Using rect()+fill(), the object is painted below its children as expected.

Now the trick begins: when an object has a "clipChildren" property with a truthly value, the following happens:
1. canvas.fillRect() function is replaced by fillRectClipping function (line 159).
2. object's draw() function is invoked (line 160).
3. canvas.fillRect() function is restored (line 161).
4. canvas.clip() function is invoked (line 162).

When "clipChildren" property is not defined or it has a falsy value, only "obj.draw()" is invoked.